### PR TITLE
Fix possible exception due to an invalid SQL query and make project compatible with .NET 8

### DIFF
--- a/src/AnkiNet/CollectionFile/Database/CardRepository.cs
+++ b/src/AnkiNet/CollectionFile/Database/CardRepository.cs
@@ -11,11 +11,13 @@ internal class CardRepository : SqliteRepository<card>
 
     protected override string TableName => "[cards]";
 
-    protected override string Columns =>
-        "[id], [nid], [did], [ord], [mod], " +
-        "[usn], [type], [queue], [due], [ivl], " +
-        "[factor], [reps], [lapses], [left], [odue]," +
-        "[odid], [flags], [data]";
+    protected override IReadOnlyList<string> Columns { get; } =
+        [
+            "[id]", "[nid]", "[did]", "[ord]", "[mod]",
+            "[usn]", "[type]", "[queue]", "[due]", "[ivl]",
+            "[factor]", "[reps]", "[lapses]", "[left]", "[odue]",
+            "[odid]", "[flags]", "[data]"
+        ];
 
     protected override IReadOnlyList<object> GetValues(card i)
     {

--- a/src/AnkiNet/CollectionFile/Database/CardRepository.cs
+++ b/src/AnkiNet/CollectionFile/Database/CardRepository.cs
@@ -17,13 +17,14 @@ internal class CardRepository : SqliteRepository<card>
         "[factor], [reps], [lapses], [left], [odue]," +
         "[odid], [flags], [data]";
 
-    protected override string GetValues(card i)
+    protected override IReadOnlyList<object> GetValues(card i)
     {
-        return
-            $"{i.id},{i.nid},{i.did},{i.ord},{i.mod}," +
-            $"{i.usn},{i.type},{i.queue},{i.due},{i.ivl}," +
-            $"{i.factor},{i.reps},{i.lapses},{i.left},{i.odue}," +
-            $"{i.odid},{i.flags},'{i.data}'";
+        return [
+            i.id, i.nid, i.did, i.ord, i.mod,
+            i.usn, i.type, i.queue, i.due, i.ivl,
+            i.factor, i.reps, i.lapses, i.left, i.odue,
+            i.odid, i.flags, i.data
+        ];
     }
 
     protected override card Map(SqliteDataReader reader)

--- a/src/AnkiNet/CollectionFile/Database/ColRepository.cs
+++ b/src/AnkiNet/CollectionFile/Database/ColRepository.cs
@@ -16,12 +16,13 @@ internal class ColRepository : SqliteRepository<col>
         "[dty], [usn], [ls], [conf], [models], " +
         "[decks], [dconf], [tags]";
 
-    protected override string GetValues(col i)
+    protected override IReadOnlyList<object> GetValues(col i)
     {
-        return
-            $"{i.id},{i.crt},{i.mod},{i.scm},{i.ver}," +
-            $"{i.dty},{i.usn},{i.ls},'{i.conf}','{i.models}'," +
-            $"'{i.decks}','{i.dconf}','{i.tags}'";
+        return [
+            i.id, i.crt, i.mod, i.scm, i.ver,
+            i.dty, i.usn, i.ls, i.conf, i.models,
+            i.decks, i.dconf, i.tags
+        ];
     }
 
     protected override col Map(SqliteDataReader reader)

--- a/src/AnkiNet/CollectionFile/Database/ColRepository.cs
+++ b/src/AnkiNet/CollectionFile/Database/ColRepository.cs
@@ -11,10 +11,12 @@ internal class ColRepository : SqliteRepository<col>
 
     protected override string TableName => "[col]";
 
-    protected override string Columns =>
-        "[id], [crt], [mod], [scm], [ver], " +
-        "[dty], [usn], [ls], [conf], [models], " +
-        "[decks], [dconf], [tags]";
+    protected override IReadOnlyList<string> Columns { get; } =
+        [
+            "[id]", "[crt]", "[mod]", "[scm]", "[ver]",
+            "[dty]", "[usn]", "[ls]", "[conf]", "[models]",
+            "[decks]", "[dconf]", "[tags]"
+        ];
 
     protected override IReadOnlyList<object> GetValues(col i)
     {

--- a/src/AnkiNet/CollectionFile/Database/GraveRepository.cs
+++ b/src/AnkiNet/CollectionFile/Database/GraveRepository.cs
@@ -11,7 +11,8 @@ internal class GraveRepository : SqliteRepository<grave>
 
     protected override string TableName => "[graves]";
 
-    protected override string Columns => "[usn], [oid], [type]";
+    protected override IReadOnlyList<string> Columns { get; } =
+        ["[usn]", "[oid]", "[type]"];
 
     protected override IReadOnlyList<object> GetValues(grave i)
     {

--- a/src/AnkiNet/CollectionFile/Database/GraveRepository.cs
+++ b/src/AnkiNet/CollectionFile/Database/GraveRepository.cs
@@ -13,9 +13,9 @@ internal class GraveRepository : SqliteRepository<grave>
 
     protected override string Columns => "[usn], [oid], [type]";
 
-    protected override string GetValues(grave i)
+    protected override IReadOnlyList<object> GetValues(grave i)
     {
-        return $"{i.usn},{i.oid},{i.type}";
+        return [i.usn, i.oid, i.type];
     }
 
     protected override grave Map(SqliteDataReader reader)

--- a/src/AnkiNet/CollectionFile/Database/NoteRepository.cs
+++ b/src/AnkiNet/CollectionFile/Database/NoteRepository.cs
@@ -17,13 +17,14 @@ internal class NoteRepository : SqliteRepository<note>
         "[flds], [sfld], [csum], " +
         "[flags], [data]";
 
-    protected override string GetValues(note i)
+    protected override IReadOnlyList<object> GetValues(note i)
     {
-        return
-            $"{i.id},'{i.guid}',{i.mid}," +
-            $"{i.mod},{i.usn},'{i.tags}'," +
-            $"'{i.flds}','{i.sfld}',{i.csum}," +
-            $"{i.flags},'{i.data}'";
+        return [
+            i.id, i.guid, i.mid,
+            i.mod, i.usn, i.tags,
+            i.flds, i.sfld, i.csum,
+            i.flags, i.data
+        ];
     }
 
     protected override note Map(SqliteDataReader reader)

--- a/src/AnkiNet/CollectionFile/Database/NoteRepository.cs
+++ b/src/AnkiNet/CollectionFile/Database/NoteRepository.cs
@@ -11,11 +11,13 @@ internal class NoteRepository : SqliteRepository<note>
 
     protected override string TableName => "[notes]";
 
-    protected override string Columns =>
-        "[id], [guid], [mid], " +
-        "[mod], [usn], [tags], " +
-        "[flds], [sfld], [csum], " +
-        "[flags], [data]";
+    protected override IReadOnlyList<string> Columns { get; } =
+        [
+            "[id]", "[guid]", "[mid]",
+            "[mod]", "[usn]", "[tags]",
+            "[flds]", "[sfld]", "[csum]",
+            "[flags]", "[data]"
+        ];
 
     protected override IReadOnlyList<object> GetValues(note i)
     {

--- a/src/AnkiNet/CollectionFile/Database/RevLogRepository.cs
+++ b/src/AnkiNet/CollectionFile/Database/RevLogRepository.cs
@@ -15,11 +15,12 @@ internal class RevLogRepository : SqliteRepository<revLog>
         "[id], [cid], [usn], [ease], [ivl], " +
         "[lastIvl], [factor], [time], [type]";
 
-    protected override string GetValues(revLog i)
+    protected override IReadOnlyList<object> GetValues(revLog i)
     {
-        return
-            $"{i.id},{i.cid},{i.usn},{i.ease},{i.ivl}," +
-            $"{i.lastIvl},{i.factor},{i.time},{i.type}";
+        return [
+            i.id, i.cid, i.usn, i.ease, i.ivl,
+            i.lastIvl, i.factor, i.time, i.type
+        ];
     }
 
     protected override revLog Map(SqliteDataReader reader)

--- a/src/AnkiNet/CollectionFile/Database/RevLogRepository.cs
+++ b/src/AnkiNet/CollectionFile/Database/RevLogRepository.cs
@@ -11,9 +11,11 @@ internal class RevLogRepository : SqliteRepository<revLog>
 
     protected override string TableName => "[revlog]";
 
-    protected override string Columns =>
-        "[id], [cid], [usn], [ease], [ivl], " +
-        "[lastIvl], [factor], [time], [type]";
+    protected override IReadOnlyList<string> Columns { get; } =
+        [
+            "[id]", "[cid]", "[usn]", "[ease]", "[ivl]",
+            "[lastIvl]", "[factor]", "[time]", "[type]"
+        ];
 
     protected override IReadOnlyList<object> GetValues(revLog i)
     {

--- a/src/AnkiNet/CollectionFile/Mapper/CollectionMapper.cs
+++ b/src/AnkiNet/CollectionFile/Mapper/CollectionMapper.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
 using AnkiNet.CollectionFile.Database.Model;
 using AnkiNet.CollectionFile.Model;
 using AnkiNet.CollectionFile.Model.Json;
@@ -7,12 +8,17 @@ namespace AnkiNet.CollectionFile.Mapper;
 
 internal static class CollectionMapper
 {
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        TypeInfoResolver = new DefaultJsonTypeInfoResolver(),
+    };
+
     public static Collection FromDb(col col)
     {
-        var configuration = JsonSerializer.Deserialize<JsonConfiguration>(col.conf);
-        var models = JsonSerializer.Deserialize<Dictionary<long, JsonModel>>(col.models);
-        var decks = JsonSerializer.Deserialize<Dictionary<long, JsonDeck>>(col.decks);
-        var decksConfiguration = JsonSerializer.Deserialize<Dictionary<long, JsonDeckConfguration>>(col.dconf);
+        var configuration = JsonSerializer.Deserialize<JsonConfiguration>(col.conf, SerializerOptions);
+        var models = JsonSerializer.Deserialize<Dictionary<long, JsonModel>>(col.models, SerializerOptions);
+        var decks = JsonSerializer.Deserialize<Dictionary<long, JsonDeck>>(col.decks, SerializerOptions);
+        var decksConfiguration = JsonSerializer.Deserialize<Dictionary<long, JsonDeckConfguration>>(col.dconf, SerializerOptions);
 
         return new Collection(
             col.id,
@@ -33,10 +39,10 @@ internal static class CollectionMapper
 
     public static col ToDb(Collection collection)
     {
-        var conf = JsonSerializer.Serialize(collection.Configuration);
-        var models = JsonSerializer.Serialize(collection.Models);
-        var decks = JsonSerializer.Serialize(collection.Decks);
-        var dconf = JsonSerializer.Serialize(collection.DecksConfiguration);
+        var conf = JsonSerializer.Serialize(collection.Configuration, SerializerOptions);
+        var models = JsonSerializer.Serialize(collection.Models, SerializerOptions);
+        var decks = JsonSerializer.Serialize(collection.Decks, SerializerOptions);
+        var dconf = JsonSerializer.Serialize(collection.DecksConfiguration, SerializerOptions);
 
         return new col(
             collection.Id,


### PR DESCRIPTION
This pull request fixes two issues:

1. An exception which may occur during insertion of notes because strings are not properly escaped.
   (This has been fixed by using SQL parameters.)
2. An exception which occurs when this library is used with a .NET 8 project because the internally used JSON serializer is missing a `TypeInfoResolver` configuration.
   (This has been fixed by configuring the JSON serializer with a `DefaultJsonTypeInfoResolver`.