### PR TITLE
added Anki's default styling to the example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ var noteType = new AnkiNoteType(
             AnswerFormat: "{{Front}}<hr id=\"answer\">{{Back}}"
         )
     },
-    fieldNames: new[] { "Front", "Back" }
+    fieldNames: new[] { "Front", "Back" },
+    css: ".card {font-family: arial;font-size: 20px;text-align: center;color: black;background-color: white;}"
 );
 
 var collection = new AnkiCollection();


### PR DESCRIPTION
Took me quite some time to figure out why the cards I had generated looked weird. 
IMO it's a sane default and what most people are looking for, so it should be part of the example on top of the README.